### PR TITLE
Fixed travis build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
+# Eclipse
 .classpath
 .settings
 .project
+
+# IntelliJ
+.idea
+*.iml
+
+# Java
 target

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ before_install:
   - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
   - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
 deploy:
-  - 
-    provider: script
-    script: .travis/deploy.sh
+  - provider: script
+    script: ./.travis/deploy.sh
+    skip_cleanup: true
     on:
       repo: DracoBlue/http-response-headers
       branch: master
       jdk: oraclejdk8
-  - 
-    provider: script
-    script: .travis/deploy.sh
+  - provider: script
+    script: ./.travis/deploy.sh
+    skip_cleanup: true
     on:
       repo: DracoBlue/http-response-headers
       tags: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # net.dracoblue.spring:http-response-headers CHANGELOG
 
+## 0.1.1
+- fixed travis build by skipping cleanup and calling the deploy script
+ with a relative path
+- ignore IntellJ folders
+
 ## 0.1.0
 
 - added maven central deployment with travis


### PR DESCRIPTION
Hi Jan,

awesome work with your [blog entry](https://dracoblue.net/dev/uploading-snapshots-and-releases-to-maven-central-with-travis/) about _Uploading Snapshots and Releases to Maven Central with Travis_! It helped me a lot adapting it to my own project.

I adapted it and encountered some problem with the travis build. After some research I found [this](https://github.com/filipre/travis-deploy-script-yml) project, which was referred in some gh issues. 
I saw you last build was about 10 months ago. So could you trigger another build so see if it still works with the current settings? 

If it fails, you could use my PR which fixes the build by skipping cleanup and calling the deploy script with a relative path.

Cheers Manu